### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = "python Main.py"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A *slightly* less clumsy python bot for discord
 
 ***
-
+[![Run on Repl.it](https://repl.it/badge/github/sahadikr1/sahadikr1sasa)](https://repl.it/github/sahadikr1/sahadikr1sasa)
 # Basic Settings
 
 The bot's basic settings should be in a file called `settings_dict.json` in the same folder as the `Main.py` file.  Some basic formatting of this file would look like so:


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).